### PR TITLE
changed source key from rpm to epel-release.

### DIFF
--- a/epel/init.sls
+++ b/epel/init.sls
@@ -25,7 +25,7 @@ install_rpm:
   pkg:
     - installed
     - sources:
-      - rpm: {{ salt['pillar.get']('epel:rpm', pkg.rpm) }}
+      - epel-release: {{ salt['pillar.get']('epel:rpm', pkg.rpm) }}
     - requires:
       - file: install_pubkey
 


### PR DESCRIPTION
The key for the source is used to check whether the package is already installed.  When set to "rpm", it finds the rpm package already installed on the system, and moves on without installing the epel package.  This is resolved by using the name of the package (epel-release) instead.
