### PR TITLE
Fixed grain matching on Amazon Linux

### DIFF
--- a/epel/init.sls
+++ b/epel/init.sls
@@ -20,7 +20,7 @@
     'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
     'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-2.noarch.rpm',
   } %}
-{% elif grains['os'] == 'Amazon' and grains['osmajorrelease'][0] == '2014' %}
+{% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2014' %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',


### PR DESCRIPTION
The osmajorrelease grain on Amazon Linux has only one element, and doesn't currently get matched correctly, resulting in the following error. This patch fixes that:

```
- Rendering SLS "base:epel" failed: Jinja variable 'pkg' is undefined; line 36
- 
- ---
- [...]
- 
- install_pubkey:
-   file:
-     - managed
-     - name: /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL
-     - source: {{ salt['pillar.get']('epel:pubkey', pkg.key) }}    <======================
-     - source_hash:  {{ salt['pillar.get']('epel:pubkey_hash', pkg.key_hash) }}
- 
- epel_release:
-   pkg:
-     - installed
- [...]
- ---
```
