### PR TITLE
Force usage of verified gpg key

### DIFF
--- a/epel/init.sls
+++ b/epel/init.sls
@@ -35,12 +35,31 @@ install_pubkey_epel:
     - source: {{ salt['pillar.get']('epel:pubkey', pkg.key) }}
     - source_hash:  {{ salt['pillar.get']('epel:pubkey_hash', pkg.key_hash) }}
 
+
 epel_release:
   pkg.installed:
     - sources:
       - epel-release: {{ salt['pillar.get']('epel:rpm', pkg.rpm) }}
     - requires:
       - file: install_pubkey_epel
+
+set_pubkey_epel:
+  file.replace:
+    - append_if_not_found: True
+    - name: /etc/yum.repos.d/epel.repo
+    - pattern: '^gpgkey=.*'
+    - repl: 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL'
+    - requires:
+      - pkg: epel-release
+
+set_gpg_epel:
+  file.replace:
+    - append_if_not_found: True
+    - name: /etc/yum.repos.d/epel.repo
+    - pattern: 'gpgcheck=.*'
+    - repl: 'gpgcheck=1'
+    - requires:
+      - pkg: epel-release
 
 {% if salt['pillar.get']('epel:disabled', False) %}
 disable_epel:

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -29,7 +29,7 @@
 {% endif %}
 
 
-install_pubkey:
+install_pubkey_epel:
   file.managed:
     - name: /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL
     - source: {{ salt['pillar.get']('epel:pubkey', pkg.key) }}
@@ -40,7 +40,7 @@ epel_release:
     - sources:
       - epel-release: {{ salt['pillar.get']('epel:rpm', pkg.rpm) }}
     - requires:
-      - file: install_pubkey
+      - file: install_pubkey_epel
 
 {% if salt['pillar.get']('epel:disabled', False) %}
 disable_epel:


### PR DESCRIPTION
I have found that epel RPM installs and uses different GPG keyfile than the pubkey we are installing in install_pubkey, rendering the checksums void. Fixed it to be on safe side.

The renaming of install_pubkey state is in extra commit and isn't essential. But it's good to avoid conflicts.