### PR TITLE
Change key/hash/rpm mappings to use map.jinja.

### DIFF
--- a/epel/init.sls
+++ b/epel/init.sls
@@ -1,45 +1,18 @@
+{% from "epel/map.jinja" import epel with context %}
+
 # Completely ignore non-RHEL based systems
 {% if grains['os_family'] == 'RedHat' %}
-
-# A lookup table for EPEL GPG keys & RPM URLs for various RedHat releases
-{% if grains['osmajorrelease'][0] == '5' %}
-  {% set pkg = {
-    'key': 'https://fedoraproject.org/static/A4D647E9.txt',
-    'key_hash': 'md5=a1d12cd9628338ddb12e9561f9ac1d6a',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/5/i386/epel-release-5-4.noarch.rpm',
-  } %}
-{% elif grains['osmajorrelease'][0] == '6' %}
-  {% set pkg = {
-    'key': 'https://fedoraproject.org/static/0608B895.txt',
-    'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
-  } %}
-{% elif grains['osmajorrelease'][0] == '7' %}
-  {% set pkg = {
-    'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
-    'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm',
-  } %}
-{% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2014' %}
-  {% set pkg = {
-    'key': 'https://fedoraproject.org/static/0608B895.txt',
-    'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
-  } %}
-{% endif %}
-
 
 install_pubkey_epel:
   file.managed:
     - name: /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL
-    - source: {{ salt['pillar.get']('epel:pubkey', pkg.key) }}
-    - source_hash:  {{ salt['pillar.get']('epel:pubkey_hash', pkg.key_hash) }}
-
+    - source: {{ epel.key }}
+    - source_hash:  {{ epel.key_hash }}
 
 epel_release:
   pkg.installed:
     - sources:
-      - epel-release: {{ salt['pillar.get']('epel:rpm', pkg.rpm) }}
+      - epel-release: {{ epel.rpm }}
     - requires:
       - file: install_pubkey_epel
 

--- a/epel/map.jinja
+++ b/epel/map.jinja
@@ -1,0 +1,27 @@
+{% set epel = salt['grains.filter_by']({
+  '5': {
+    'key': 'https://fedoraproject.org/static/A4D647E9.txt',
+    'key_hash': 'md5=a1d12cd9628338ddb12e9561f9ac1d6a',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/5/i386/epel-release-5-4.noarch.rpm',
+  },
+  '6': {
+    'key': 'https://fedoraproject.org/static/0608B895.txt',
+    'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
+  },
+  '7': {
+    'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
+    'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm',
+  },
+  '2014': {
+    'key': 'https://fedoraproject.org/static/0608B895.txt',
+    'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
+  },
+  '2015': {
+    'key': 'https://fedoraproject.org/static/0608B895.txt',
+    'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
+  },
+}, grain='osmajorrelease', merge=salt['pillar.get']('epel:lookup')) %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,10 +1,11 @@
 epel:
-  # URL to the EPEL RPM to install
-  rpm: default varies with OS; see epel/init.sls
+  lookup:
+    # URL to the EPEL RPM to install
+    rpm: default varies with OS; see epel/init.sls
 
-  # URL to the EPEL GPG key
-  pubkey: default varies with OS; see epel/init.sls
-  pubkey_hash: default varies with OS; see epel/init.sls
+    # URL to the EPEL GPG key
+    pubkey: default varies with OS; see epel/init.sls
+    pubkey_hash: default varies with OS; see epel/init.sls
 
   # Disable repo so requires the --enablerepo flag to use
   disabled: false


### PR DESCRIPTION
Created a map.jinja to replace the if/else package and key lookups.
Added 2015 osmajorrelease for Amazon's latest AMIs
Modified pillar.example for lookup: nested under epel. This might break existing pillars due to the additional nesting of lookup:, but is more in line with other formulas' methods.