### PR TITLE
Use non-redirecting rpm urls

### DIFF
--- a/epel/init.sls
+++ b/epel/init.sls
@@ -6,31 +6,31 @@
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/A4D647E9.txt',
     'key_hash': 'md5=a1d12cd9628338ddb12e9561f9ac1d6a',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/5/i386/epel-release-5-4.noarch.rpm',
+    'rpm': 'http://dl.fedoraproject.org/pub/epel/5/i386/epel-release-5-4.noarch.rpm',
   } %}
 {% elif grains['osmajorrelease'][0] == '6' %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
+    'rpm': 'http://dl.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
   } %}
 {% elif grains['osmajorrelease'][0] == '7' %}
   {% set pkg = {
     'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
     'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm',
+    'rpm': 'http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2014' %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
+    'rpm': 'http://dl.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2015' %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
+    'rpm': 'http://dl.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
   } %}
 {% endif %}
 


### PR DESCRIPTION
We are getting 404 errors when trying to apply this state currently.
Salt doesn't seem to follow the redirect being returned from http://download.fedoraproject.org so instead I am proposing using http://dl.fedoraproject.org

```
$ curl -I http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm
HTTP/1.1 302 Found
Date: Tue, 17 May 2016 06:20:14 GMT
Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
Location: http://mirror.nsc.liu.se/fedora-epel/7/x86_64/e/epel-release-7-6.noarch.rpm
AppTime: D=155874
AppServer: proxy10.phx2.fedoraproject.org
Content-Type: text/html; charset=UTF-8
```

```
$ curl -I http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm
HTTP/1.1 200 OK
Date: Tue, 17 May 2016 06:20:53 GMT
Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips
Last-Modified: Fri, 01 Apr 2016 23:29:25 GMT
ETag: "3860-52f74bfd9ff40"
Accept-Ranges: bytes
Content-Length: 14432
AppTime: D=3709
AppServer: download03.phx2.fedoraproject.org
Content-Type: application/x-rpm
```