### PR TITLE
Formula cleanups : map.jinja, sha256

### DIFF
--- a/epel/init.sls
+++ b/epel/init.sls
@@ -4,29 +4,29 @@
 # A lookup table for EPEL GPG keys & RPM URLs for various RedHat releases
 {% if grains['osmajorrelease'][0] == '5' %}
   {% set pkg = {
-    'key': 'https://fedoraproject.org/static/A4D647E9.txt',
-    'key_hash': 'md5=a1d12cd9628338ddb12e9561f9ac1d6a',
+    'key': 'https://getfedora.org/static/A4D647E9.txt',
+    'key_hash': 'sha256=664c06f579d914f2cf25d05d4d581b8ddec77cae4f72f4020c3a9264b9d5ee71',
     'key_name': 'RPM-GPG-KEY-EPEL-5',
     'rpm': 'http://download.fedoraproject.org/pub/epel/5/i386/epel-release-5-4.noarch.rpm',
   } %}
 {% elif grains['osmajorrelease'][0] == '6' %}
   {% set pkg = {
-    'key': 'https://fedoraproject.org/static/0608B895.txt',
-    'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
+    'key': 'https://getfedora.org/static/0608B895.txt',
+    'key_hash': 'sha256=16d35fa467c6efcee21d3aa068a02054b6a89a7a33bffa94db1fc141693d62a3',
     'key_name': 'RPM-GPG-KEY-EPEL-6',
     'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
   } %}
 {% elif grains['osmajorrelease'][0] == '7' %}
   {% set pkg = {
-    'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
-    'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
+    'key': 'https://getfedora.org/static/352C64E5.txt',
+    'key_hash': 'sha256=22f25ad95d5e8d371760815485dba696ea3002fc2c7f812f2c75276853387107',
     'key_name': 'RPM-GPG-KEY-EPEL-7',
     'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] in ['2014', '2015', '2016' ]  %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
-    'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
+    'key_hash': 'sha256=16d35fa467c6efcee21d3aa068a02054b6a89a7a33bffa94db1fc141693d62a3',
     'key_name': 'RPM-GPG-KEY-EPEL-6',
     'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
   } %}

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -1,49 +1,19 @@
 # Completely ignore non-RHEL based systems
 {% if grains['os_family'] == 'RedHat' %}
 
-# A lookup table for EPEL GPG keys & RPM URLs for various RedHat releases
-{% if grains['osmajorrelease'][0] == '5' %}
-  {% set pkg = {
-    'key': 'https://getfedora.org/static/A4D647E9.txt',
-    'key_hash': 'sha256=664c06f579d914f2cf25d05d4d581b8ddec77cae4f72f4020c3a9264b9d5ee71',
-    'key_name': 'RPM-GPG-KEY-EPEL-5',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/5/i386/epel-release-5-4.noarch.rpm',
-  } %}
-{% elif grains['osmajorrelease'][0] == '6' %}
-  {% set pkg = {
-    'key': 'https://getfedora.org/static/0608B895.txt',
-    'key_hash': 'sha256=16d35fa467c6efcee21d3aa068a02054b6a89a7a33bffa94db1fc141693d62a3',
-    'key_name': 'RPM-GPG-KEY-EPEL-6',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
-  } %}
-{% elif grains['osmajorrelease'][0] == '7' %}
-  {% set pkg = {
-    'key': 'https://getfedora.org/static/352C64E5.txt',
-    'key_hash': 'sha256=22f25ad95d5e8d371760815485dba696ea3002fc2c7f812f2c75276853387107',
-    'key_name': 'RPM-GPG-KEY-EPEL-7',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm',
-  } %}
-{% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] in ['2014', '2015', '2016' ]  %}
-  {% set pkg = {
-    'key': 'https://fedoraproject.org/static/0608B895.txt',
-    'key_hash': 'sha256=16d35fa467c6efcee21d3aa068a02054b6a89a7a33bffa94db1fc141693d62a3',
-    'key_name': 'RPM-GPG-KEY-EPEL-6',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
-  } %}
-{% endif %}
-
+{% from "epel/map.jinja" import epel with context %}
 
 install_pubkey_epel:
   file.managed:
-    - name: /etc/pki/rpm-gpg/{{ salt['pillar.get']('epel:pubkey_name', pkg.key_name) }}
-    - source: {{ salt['pillar.get']('epel:pubkey', pkg.key) }}
-    - source_hash:  {{ salt['pillar.get']('epel:pubkey_hash', pkg.key_hash) }}
+    - name: /etc/pki/rpm-gpg/{{ epel.key_name }}
+    - source: {{ epel.key }}
+    - source_hash:  {{ epel.key_hash }}
 
 
 epel_release:
   pkg.installed:
     - sources:
-      - epel-release: {{ salt['pillar.get']('epel:rpm', pkg.rpm) }}
+      - epel-release: {{ epel.rpm }}
     - require:
       - file: install_pubkey_epel
 
@@ -52,7 +22,7 @@ set_pubkey_epel:
     - append_if_not_found: True
     - name: /etc/yum.repos.d/epel.repo
     - pattern: '^\s*gpgkey=.*'
-    - repl: 'gpgkey=file:///etc/pki/rpm-gpg/{{ salt['pillar.get']('epel:pubkey_name', pkg.key_name) }}'
+    - repl: 'gpgkey=file:///etc/pki/rpm-gpg/{{ epel.key_name }}'
     - require:
       - pkg: epel_release
 
@@ -65,7 +35,7 @@ set_gpg_epel:
     - require:
       - pkg: epel_release
 
-{% if salt['pillar.get']('epel:disabled', False) %}
+{% if epel.disabled %}
 disable_epel:
   file.replace:
     - name: /etc/yum.repos.d/epel.repo

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -51,7 +51,7 @@ set_pubkey_epel:
   file.replace:
     - append_if_not_found: True
     - name: /etc/yum.repos.d/epel.repo
-    - pattern: '^gpgkey=.*'
+    - pattern: '^\s*gpgkey=.*'
     - repl: 'gpgkey=file:///etc/pki/rpm-gpg/{{ salt['pillar.get']('epel:pubkey_name', pkg.key_name) }}'
     - require:
       - pkg: epel_release
@@ -60,7 +60,7 @@ set_gpg_epel:
   file.replace:
     - append_if_not_found: True
     - name: /etc/yum.repos.d/epel.repo
-    - pattern: 'gpgcheck=.*'
+    - pattern: '^\s*gpgcheck=.*'
     - repl: 'gpgcheck=1'
     - require:
       - pkg: epel_release
@@ -69,13 +69,13 @@ set_gpg_epel:
 disable_epel:
   file.replace:
     - name: /etc/yum.repos.d/epel.repo
-    - pattern: '^enabled=[0,1]'
+    - pattern: '^\s*enabled=[0,1]'
     - repl: 'enabled=0'
 {% else %}
 enable_epel:
   file.replace:
     - name: /etc/yum.repos.d/epel.repo
-    - pattern: '^enabled=[0,1]'
+    - pattern: '^\s*enabled=[0,1]'
     - repl: 'enabled=1'
 {% endif %}
 {% endif %}

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -23,14 +23,7 @@
     'key_name': 'RPM-GPG-KEY-EPEL-7',
     'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm',
   } %}
-{% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2014' %}
-  {% set pkg = {
-    'key': 'https://fedoraproject.org/static/0608B895.txt',
-    'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
-    'key_name': 'RPM-GPG-KEY-EPEL-6',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
-  } %}
-{% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2015' %}
+{% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] in ['2014', '2015', '2016' ]  %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -6,30 +6,35 @@
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/A4D647E9.txt',
     'key_hash': 'md5=a1d12cd9628338ddb12e9561f9ac1d6a',
+    'key_name': 'RPM-GPG-KEY-EPEL-5',
     'rpm': 'http://download.fedoraproject.org/pub/epel/5/i386/epel-release-5-4.noarch.rpm',
   } %}
 {% elif grains['osmajorrelease'][0] == '6' %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
+    'key_name': 'RPM-GPG-KEY-EPEL-6',
     'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
   } %}
 {% elif grains['osmajorrelease'][0] == '7' %}
   {% set pkg = {
     'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
     'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
+    'key_name': 'RPM-GPG-KEY-EPEL-7',
     'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2014' %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
+    'key_name': 'RPM-GPG-KEY-EPEL-6',
     'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2015' %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
+    'key_name': 'RPM-GPG-KEY-EPEL-6',
     'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
   } %}
 {% endif %}
@@ -37,7 +42,7 @@
 
 install_pubkey_epel:
   file.managed:
-    - name: /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL
+    - name: /etc/pki/rpm-gpg/{{ salt['pillar.get']('epel:pubkey_name', pkg.key_name) }}
     - source: {{ salt['pillar.get']('epel:pubkey', pkg.key) }}
     - source_hash:  {{ salt['pillar.get']('epel:pubkey_hash', pkg.key_hash) }}
 
@@ -54,7 +59,7 @@ set_pubkey_epel:
     - append_if_not_found: True
     - name: /etc/yum.repos.d/epel.repo
     - pattern: '^gpgkey=.*'
-    - repl: 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL'
+    - repl: 'gpgkey=file:///etc/pki/rpm-gpg/{{ salt['pillar.get']('epel:pubkey_name', pkg.key_name) }}'
     - require:
       - pkg: epel_release
 

--- a/epel/map.jinja
+++ b/epel/map.jinja
@@ -1,23 +1,14 @@
-# Enable by default
-{% set epel={
-  'disabled': False,
-  'key_name': 'RPM-GPG-KEY-EPEL',
-}
- %}
-
-# specific map for Amazon linux
-{% if grains['os'] == 'Amazon' and grains['osmajorrelease'] in ['2014', '2015', '2016' ]  %}
-  {% set os_map = {
-    'key': 'https://fedoraproject.org/static/0608B895.txt',
-    'key_hash': 'sha256=16d35fa467c6efcee21d3aa068a02054b6a89a7a33bffa94db1fc141693d62a3',
-    'key_name': 'RPM-GPG-KEY-EPEL-6',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
-  } %}
-
-{% else %}
-
-# A lookup table for EPEL GPG keys & RPM URLs for various RedHat releases
-  {% set os_map = salt['grains.filter_by']({
+{% set epel= salt['grains.filter_by'] ({
+    'common':{
+      'disabled': False,
+    },
+    'Amazon': {
+      'key': 'https://fedoraproject.org/static/0608B895.txt',
+      'key_hash': 'sha256=16d35fa467c6efcee21d3aa068a02054b6a89a7a33bffa94db1fc141693d62a3',
+      'key_name': 'RPM-GPG-KEY-EPEL-6',
+      'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
+    },
+    'RedHat': salt['grains.filter_by']({
       '5': {
         'key': 'https://getfedora.org/static/A4D647E9.txt',
         'key_hash': 'sha256=664c06f579d914f2cf25d05d4d581b8ddec77cae4f72f4020c3a9264b9d5ee71',
@@ -36,16 +27,11 @@
         'key_name': 'RPM-GPG-KEY-EPEL-7',
         'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm',
       },
-    }
-    , grain='osmajorrelease')
-  %}
-{% endif %}
-
-# merge defaults
-{% do epel.update(os_map) %}
-
-# keeps legacy epel pillar , to be removed at a later time
-{% do epel.update(salt['pillar.get']('epel')) %}
-
-# merge pillar data from epel:lookup subkey
-{% do epel.update(salt['pillar.get']('epel:lookup')) %}
+    },
+    grain='osmajorrelease')
+  },
+  grain='os',
+  merge=salt['pillar.get']('epel:lookup'),
+  default='RedHat',
+  base='common' )
+-%}

--- a/epel/map.jinja
+++ b/epel/map.jinja
@@ -41,7 +41,11 @@
   %}
 {% endif %}
 
-# merge default and pillar data
+# merge defaults
 {% do epel.update(os_map) %}
 
+# keeps legacy epel pillar , to be removed at a later time
 {% do epel.update(salt['pillar.get']('epel')) %}
+
+# merge pillar data from epel:lookup subkey
+{% do epel.update(salt['pillar.get']('epel:lookup')) %}

--- a/epel/map.jinja
+++ b/epel/map.jinja
@@ -1,0 +1,47 @@
+# Enable by default
+{% set epel={
+  'disabled': False,
+  'key_name': 'RPM-GPG-KEY-EPEL',
+}
+ %}
+
+# specific map for Amazon linux
+{% if grains['os'] == 'Amazon' and grains['osmajorrelease'] in ['2014', '2015', '2016' ]  %}
+  {% set os_map = {
+    'key': 'https://fedoraproject.org/static/0608B895.txt',
+    'key_hash': 'sha256=16d35fa467c6efcee21d3aa068a02054b6a89a7a33bffa94db1fc141693d62a3',
+    'key_name': 'RPM-GPG-KEY-EPEL-6',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
+  } %}
+
+{% else %}
+
+# A lookup table for EPEL GPG keys & RPM URLs for various RedHat releases
+  {% set os_map = salt['grains.filter_by']({
+      '5': {
+        'key': 'https://getfedora.org/static/A4D647E9.txt',
+        'key_hash': 'sha256=664c06f579d914f2cf25d05d4d581b8ddec77cae4f72f4020c3a9264b9d5ee71',
+        'key_name': 'RPM-GPG-KEY-EPEL-5',
+        'rpm': 'http://download.fedoraproject.org/pub/epel/5/i386/epel-release-5-4.noarch.rpm',
+      },
+      '6': {
+        'key': 'https://getfedora.org/static/0608B895.txt',
+        'key_hash': 'sha256=16d35fa467c6efcee21d3aa068a02054b6a89a7a33bffa94db1fc141693d62a3',
+        'key_name': 'RPM-GPG-KEY-EPEL-6',
+        'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
+      },
+      '7': {
+        'key': 'https://getfedora.org/static/352C64E5.txt',
+        'key_hash': 'sha256=22f25ad95d5e8d371760815485dba696ea3002fc2c7f812f2c75276853387107',
+        'key_name': 'RPM-GPG-KEY-EPEL-7',
+        'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm',
+      },
+    }
+    , grain='osmajorrelease')
+  %}
+{% endif %}
+
+# merge default and pillar data
+{% do epel.update(os_map) %}
+
+{% do epel.update(salt['pillar.get']('epel')) %}

--- a/pillar.example
+++ b/pillar.example
@@ -3,9 +3,11 @@ epel:
   rpm: default varies with OS; see epel/init.sls
 
   # URL to the EPEL GPG key
-  pubkey: default varies with OS; see epel/init.sls
-  pubkey_hash: default varies with OS; see epel/init.sls
-  pubkey_name: default varies with OS; see epel/init.sls
+  pubkey: default varies with OS; see epel/map.jinja
+  pubkey_hash: default varies with OS; see epel/map.jinja
+
+  # filename for the local EPEL Key
+  pubkey_name: default varies with OS; see epel/map.jinja
 
   # Disable repo so requires the --enablerepo flag to use
   disabled: false

--- a/pillar.example
+++ b/pillar.example
@@ -5,6 +5,7 @@ epel:
   # URL to the EPEL GPG key
   pubkey: default varies with OS; see epel/init.sls
   pubkey_hash: default varies with OS; see epel/init.sls
+  pubkey_name: default varies with OS; see epel/init.sls
 
   # Disable repo so requires the --enablerepo flag to use
   disabled: false

--- a/pillar.example
+++ b/pillar.example
@@ -1,13 +1,14 @@
 epel:
-  # URL to the EPEL RPM to install
-  rpm: default varies with OS; see epel/init.sls
+  lookup:
+    # URL to the EPEL RPM to install
+    rpm: default varies with OS; see epel/init.sls
 
-  # URL to the EPEL GPG key
-  pubkey: default varies with OS; see epel/map.jinja
-  pubkey_hash: default varies with OS; see epel/map.jinja
+    # URL to the EPEL GPG key
+    pubkey: default varies with OS; see epel/map.jinja
+    pubkey_hash: default varies with OS; see epel/map.jinja
 
-  # filename for the local EPEL Key
-  pubkey_name: default varies with OS; see epel/map.jinja
+    # filename for the local EPEL Key
+    pubkey_name: default varies with OS; see epel/map.jinja
 
-  # Disable repo so requires the --enablerepo flag to use
-  disabled: false
+    # Disable repo so requires the --enablerepo flag to use
+    disabled: false


### PR DESCRIPTION
Hi
This pull request contains an updated epel formula to be a bit closer to best practices , mainly : 
- uses a map.jinja,similar to pull #18   with overrides in pillar using a lookup subkey, and special case for amazon linux
- updates the gpg key to use the official ones from https://getfedora.org/keys/
- adds by default epel version in the key name
- updates the hashes from md5 to sha256
- makes edition of repo files for enabling and gpg key a bit more robust
- incidentaly adds an amazon linux 2016 version I used for testing
