### PR TITLE
EPEL release 7-7 and pillar support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,3 +21,5 @@ Available states
 Installs the GPG key and EPEL RPM package for the current OS.
 
 The EPEL testing repository can be enabled by setting the Pillar ``epel:testing: true``.
+
+The EPEL release to be installed can be defind by setting the Pillar ``epel:release: 7-8``

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -18,7 +18,7 @@
   {% set pkg = {
     'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
     'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-6', true) ~ '.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-7', true) ~ '.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2014' %}
   {% set pkg = {

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -1,36 +1,36 @@
 # Completely ignore non-RHEL based systems
 {% if grains['os_family'] == 'RedHat' %}
-
+  {% set epel_release = salt['pillar.get']('epel:release', false) %}
 # A lookup table for EPEL GPG keys & RPM URLs for various RedHat releases
 {% if grains['osmajorrelease'][0] == '5' %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/A4D647E9.txt',
     'key_hash': 'md5=a1d12cd9628338ddb12e9561f9ac1d6a',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/5/i386/epel-release-5-4.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/5/i386/epel-release-' ~ epel_release|default('5-4', true) ~ '.noarch.rpm',
   } %}
 {% elif grains['osmajorrelease'][0] == '6' %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-' ~ epel_release|default('6-8', true) ~ '.noarch.rpm',
   } %}
 {% elif grains['osmajorrelease'][0] == '7' %}
   {% set pkg = {
     'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
     'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-6', true) ~ '.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2014' %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-' ~ epel_release|default('6-8', true) ~ '.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2015' %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-' ~ epel_release|default('6-8', true) ~ '.noarch.rpm',
   } %}
 {% endif %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -11,3 +11,6 @@ epel:
 
   # Disable (default)/enable EPEL testing
   testing: false
+
+  # Override the default EPEL release version
+  release: 7-8


### PR DESCRIPTION
This allows to quickly define a newer EPEL release than hardcoded in the Formula by simply setting the Pillar `epel:release`.

Besides that, it updates the default release on RHEL/CentOS 7 to 7-7 (see also: #25, which would be obsoleted by this PR).