### PR TITLE
Update epel-release rpm version to 7-10 for Redhat/CentOS version 7

### DIFF
--- a/epel/init.sls
+++ b/epel/init.sls
@@ -18,7 +18,7 @@
   {% set pkg = {
     'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
     'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
-    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-9', true) ~ '.noarch.rpm',
+    'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-10', true) ~ '.noarch.rpm',
   } %}
 {% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2014' %}
   {% set pkg = {


### PR DESCRIPTION
Attempts to fix https://github.com/saltstack-formulas/epel-formula/issues/31

Mirror sites providing the 7-9.rpm has moved to the newer version of 7-10.rpm since late Jun 2017 (e.g. http://ftp.jaist.ac.jp/pub/Linux/Fedora/epel/7/x86_64/e/) and 7-9.rpm is no longer available, causing pkg.installed salt state that requires epel-release for Redhat/CentOS7 to fail intermittently due to:

```
--2017-07-12 14:14:46--  http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
Resolving download.fedoraproject.org... 8.43.85.67, 209.132.181.16, 140.211.169.196, ...
Connecting to download.fedoraproject.org|8.43.85.67|:80... connected.
HTTP request sent, awaiting response... 302 Found
Location: http://ftp.riken.jp/Linux/fedora/epel/7/x86_64/e/epel-release-7-9.noarch.rpm [following]
--2017-07-12 14:14:46--  http://ftp.riken.jp/Linux/fedora/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
Resolving ftp.riken.jp... 134.160.38.1
Connecting to ftp.riken.jp|134.160.38.1|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2017-07-12 14:14:47 ERROR 404: Not Found.
```