### PR TITLE
Fixed osmajorrelease grains change in salt 2017.07

### DIFF
--- a/epel/init.sls
+++ b/epel/init.sls
@@ -2,31 +2,31 @@
 {% if grains['os_family'] == 'RedHat' %}
   {% set epel_release = salt['pillar.get']('epel:release', false) %}
 # A lookup table for EPEL GPG keys & RPM URLs for various RedHat releases
-{% if grains['osmajorrelease'] == 5 %}
+{% if ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 5 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'][0] == '5' ) %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/A4D647E9.txt',
     'key_hash': 'md5=a1d12cd9628338ddb12e9561f9ac1d6a',
     'rpm': 'http://download.fedoraproject.org/pub/epel/5/i386/epel-release-' ~ epel_release|default('5-4', true) ~ '.noarch.rpm',
   } %}
-{% elif grains['osmajorrelease'] == 6 %}
+{% elif ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 6 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'][0] == '6' ) %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
     'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-' ~ epel_release|default('6-8', true) ~ '.noarch.rpm',
   } %}
-{% elif grains['osmajorrelease'] == 7 %}
+{% elif ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 7 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'][0] == '7' ) %}
   {% set pkg = {
     'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
     'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',
     'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-' ~ epel_release|default('7-10', true) ~ '.noarch.rpm',
   } %}
-{% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2014' %}
+{% elif grains['os'] == 'Amazon' and ( ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 2014 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'] == '2014' ) ) %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
     'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-' ~ epel_release|default('6-8', true) ~ '.noarch.rpm',
   } %}
-{% elif grains['os'] == 'Amazon' and grains['osmajorrelease'] == '2015' %}
+{% elif grains['os'] == 'Amazon' and ( ( grains['saltversion'] >= '2017.7.0' and grains['osmajorrelease'] == 2015 ) or ( grains['saltversion'] < '2017.7.0' and grains['osmajorrelease'] == '2015' ) ) %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -2,19 +2,19 @@
 {% if grains['os_family'] == 'RedHat' %}
   {% set epel_release = salt['pillar.get']('epel:release', false) %}
 # A lookup table for EPEL GPG keys & RPM URLs for various RedHat releases
-{% if grains['osmajorrelease'][0] == '5' %}
+{% if grains['osmajorrelease'] == 5 %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/A4D647E9.txt',
     'key_hash': 'md5=a1d12cd9628338ddb12e9561f9ac1d6a',
     'rpm': 'http://download.fedoraproject.org/pub/epel/5/i386/epel-release-' ~ epel_release|default('5-4', true) ~ '.noarch.rpm',
   } %}
-{% elif grains['osmajorrelease'][0] == '6' %}
+{% elif grains['osmajorrelease'] == 6 %}
   {% set pkg = {
     'key': 'https://fedoraproject.org/static/0608B895.txt',
     'key_hash': 'md5=eb8749ea67992fd622176442c986b788',
     'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-' ~ epel_release|default('6-8', true) ~ '.noarch.rpm',
   } %}
-{% elif grains['osmajorrelease'][0] == '7' %}
+{% elif grains['osmajorrelease'] == 7 %}
   {% set pkg = {
     'key': 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7',
     'key_hash': 'md5=58fa8ae27c89f37b08429f04fd4a88cc',


### PR DESCRIPTION
Fixed  osmajorelease grains change from *string* to *int* to be able to use the formula in either salt 2017.07 or previous releases.

Tested in CentOS 6 and 7 (should either work in CentOS 5, same ```osmajorrelease``` pattern). If anyone can test in Amazon release I would appreciate it (it uses a different ```osmajorrelease``` pattern but should work).