### PR TITLE
Add missing default value to disable testing repo

### DIFF
--- a/epel/map.jinja
+++ b/epel/map.jinja
@@ -1,6 +1,7 @@
 {% set epel= salt['grains.filter_by'] ({
     'common':{
       'disabled': False,
+      'testing': False,
     },
     'Amazon': {
       'key': 'https://fedoraproject.org/static/0608B895.txt',


### PR DESCRIPTION
After mergin #45, the state fails to apply correctly, with the error:
```
Data failed to compile:
       ----------
           Rendering SLS 'base:epel' failed: Jinja variable 'dict object' has no attribute 'testing'
```
Pre-#45, the formula checked that parameter directly from the pillar, after the merge, it checks the parameter from map.jinja, where it does not exist. This PR adds the default value. 