### PR TITLE
Add alternative, more flexible repository configuration

### DIFF
--- a/epel/init.sls
+++ b/epel/init.sls
@@ -16,6 +16,25 @@ epel_release:
     - require:
       - file: install_pubkey_epel
 
+{% if 'repos' in epel %}
+{% for repo, config in epel.repos.items() %}
+config_repo_{{ repo }}:
+  module.run:
+    - name: pkg.mod_repo
+    - repo: {{ repo }}
+    - kwargs:
+{% if config.enabled %}
+        enabled: 1
+{% else %}
+        enabled: 0
+{% endif %}
+        gpgkey: file:///etc/pki/rpm-gpg/{{ epel.key_name }}
+        gpgcheck: 1
+    - require:
+      - pkg: epel_release
+
+{% endfor %}
+{% else %}
 set_pubkey_epel:
   file.replace:
     - append_if_not_found: True
@@ -60,5 +79,6 @@ disable_epel_testing:
     - name: /etc/yum.repos.d/epel-testing.repo
     - pattern: '^\s*enabled=[0,1]'
     - repl: 'enabled=0'
+{% endif %}
 {% endif %}
 {% endif %}

--- a/epel/init.sls
+++ b/epel/init.sls
@@ -28,6 +28,9 @@ config_repo_{{ repo }}:
 {% else %}
         enabled: 0
 {% endif %}
+{% if 'exclude' in config %}
+        exclude: {{ config.exclude|join(',') }}
+{% endif %}
         gpgkey: file:///etc/pki/rpm-gpg/{{ epel.key_name }}
         gpgcheck: 1
     - require:

--- a/pillar.example
+++ b/pillar.example
@@ -20,6 +20,9 @@ epel:
     repos:
       epel:
         enabled: true
+        exclude:
+          - pkg1
+          - pkg2
       epel-debuginfo:
         enabled: true
       epel-source:

--- a/pillar.example
+++ b/pillar.example
@@ -15,3 +15,18 @@ epel:
 
     # Disable (default)/enable EPEL testing
     testing: false
+
+    # Alternative, more detailed per-repo configuration
+    repos:
+      epel:
+        enabled: true
+      epel-debuginfo:
+        enabled: true
+      epel-source:
+        enabled: true
+      epel-testing:
+        enabled: false
+      epel-testing-debuginfo
+        enabled: false
+      epel-testing-source
+        enabled: false


### PR DESCRIPTION
Added an alternative way to the current global configuration of epel and epel-testing where each individual repo (epel-source, epel-testing-debuginfo, etc) can be configured.

I used the pkg.mod_repo module instead of the pkgrepo.managed state since the former is more flexible and allows to also configure package excludes.

I left this as an alternative to not cause any conflicts on existing environments, so it's opt-in.