### PR TITLE
Updating map to use fedoraproject.org links

### DIFF
--- a/epel/map.jinja
+++ b/epel/map.jinja
@@ -11,19 +11,19 @@
     },
     'RedHat': salt['grains.filter_by']({
       '5': {
-        'key': 'https://getfedora.org/static/A4D647E9.txt',
+        'key': 'https://fedoraproject.org/static/A4D647E9.txt',
         'key_hash': 'sha256=664c06f579d914f2cf25d05d4d581b8ddec77cae4f72f4020c3a9264b9d5ee71',
         'key_name': 'RPM-GPG-KEY-EPEL-5',
         'rpm': 'http://download.fedoraproject.org/pub/archive/epel/5/i386/epel-release-5-4.noarch.rpm',
       },
       '6': {
-        'key': 'https://getfedora.org/static/0608B895.txt',
+        'key': 'https://fedoraproject.org/static/0608B895.txt',
         'key_hash': 'sha256=16d35fa467c6efcee21d3aa068a02054b6a89a7a33bffa94db1fc141693d62a3',
         'key_name': 'RPM-GPG-KEY-EPEL-6',
         'rpm': 'http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm',
       },
       '7': {
-        'key': 'https://getfedora.org/static/352C64E5.txt',
+        'key': 'https://fedoraproject.org/static/352C64E5.txt',
         'key_hash': 'sha256=22f25ad95d5e8d371760815485dba696ea3002fc2c7f812f2c75276853387107',
         'key_name': 'RPM-GPG-KEY-EPEL-7',
         'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-11.noarch.rpm',


### PR DESCRIPTION
getfedora.org links are deprecated and broken. fedoraproject.org is the proper URL going forward.