### PR TITLE
fixing epel version 7 url

### DIFF
--- a/epel/map.jinja
+++ b/epel/map.jinja
@@ -36,7 +36,7 @@
         'key': 'https://fedoraproject.org/static/352C64E5.txt',
         'key_hash': 'sha256=22f25ad95d5e8d371760815485dba696ea3002fc2c7f812f2c75276853387107',
         'key_name': 'RPM-GPG-KEY-EPEL-7',
-        'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-11.noarch.rpm',
+        'rpm': 'http://download.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-12.noarch.rpm',
       },
       '8': {
         'key': 'https://fedoraproject.org/static/352C64E5.txt',


### PR DESCRIPTION
Looks like release 11 no longer exists in in the mirrors for epel 7. This updates the URL to release 12.