### PR TITLE
fix(map.jinja): update to `epel-release-8-11.el8.noarch.rpm`

### DIFF
--- a/epel/map.jinja
+++ b/epel/map.jinja
@@ -42,7 +42,7 @@
         'key': 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8',
         'key_hash': 'sha256=cd1db21a863185127f2e3b264c97fb1c6c44c316385707999041ea475c110d1c',
         'key_name': 'RPM-GPG-KEY-EPEL-8',
-        'rpm': 'http://download.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/e/epel-release-8-10.el8.noarch.rpm',
+        'rpm': 'http://download.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/e/epel-release-8-11.el8.noarch.rpm',
       },
     },
     grain='osmajorrelease')


### PR DESCRIPTION
A simple reflection of the EPEL release version in the upstream repo.