### PR TITLE
refactor(init.sls): apply pkg.installed retries

### DIFF
--- a/epel/init.sls
+++ b/epel/init.sls
@@ -15,6 +15,7 @@ epel_release:
       - epel-release: {{ epel.rpm }}
     - require:
       - file: install_pubkey_epel
+    - retry: {{ epel.retry_options | json }}
 
 {% if 'repos' in epel %}
 {% for repo, config in epel.repos.items() %}

--- a/epel/map.jinja
+++ b/epel/map.jinja
@@ -2,6 +2,12 @@
     'common': {
       'disabled': False,
       'testing': False,
+      'retry_options': {
+        'attempts': 3,
+        'until': True,
+        'interval': 10,
+        'splay': 10,
+      },
     },
     'Amazon': salt['grains.filter_by']({
       2: {

--- a/pillar.example
+++ b/pillar.example
@@ -36,3 +36,10 @@ epel:
         enabled: false
       epel-testing-source:
         enabled: false
+
+    # https://docs.saltproject.io/en/latest/ref/states/requisites.html#retrying-states
+    retry_options:
+      attempts: 3
+      until: true
+      interval: 10
+      splay: 10


### PR DESCRIPTION
Due to sporadical but systemic issues with external proxy timeouts (HTTP/599) for ephemeral links to the latest packages at http://download.fedoraproject.org we need to implement the retry mechanism on the corresponding `pkg.installed` state call. @myii can you assist with this?
The issue example is something like this:
```
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/state.py", line 2180, in call
    *cdata["args"], **cdata["kwargs"]
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 149, in __call__
    return self.loader.run(run_func, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1201, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/contextvars/__init__.py", line 38, in run
    return callable(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1216, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1249, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/states/pkg.py", line 1734, in installed
    **kwargs
  File "/usr/lib/python3.6/site-packages/salt/states/pkg.py", line 785, in _find_install_targets
    version_string, saltenv=kwargs["saltenv"]
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 149, in __call__
    return self.loader.run(run_func, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1201, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/contextvars/__init__.py", line 38, in run
    return callable(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1216, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/modules/cp.py", line 499, in cache_file
    path, saltenv, source_hash=source_hash, verify_ssl=verify_ssl
  File "/usr/lib/python3.6/site-packages/salt/fileclient.py", line 187, in cache_file
    verify_ssl=verify_ssl,
  File "/usr/lib/python3.6/site-packages/salt/fileclient.py", line 760, in get_url
    "Error: {} reading {}".format(query["error"], url_data.path)
salt.exceptions.MinionError: Error: HTTP 599: Timeout while connecting reading /pub/epel/epel-release-latest-7.noarch.rpm

[INFO    ] Completed state [epel_release] at time 15:54:46.839813 (duration_in_ms=20071.218)